### PR TITLE
deprecate event emitter interface

### DIFF
--- a/lib/reload.js
+++ b/lib/reload.js
@@ -1,4 +1,5 @@
 var EventEmitter = require('events').EventEmitter,
+    deprecate = require('depd')('reload-json'),
     debounce = require('debounce'),
     first = require('ee-first'),
     util = require('util'),
@@ -39,7 +40,13 @@ function ReloadJSON(options) {
     this.delay = options.delay || 10;
 }
 
-util.inherits(ReloadJSON, EventEmitter);
+// Extend event emitter to provide some insight to what's going on internally
+// this is pretty bad idea and is considered deprecated. `change` and `load`
+// events are still emitted but no more `error` events.
+util.inherits(ReloadJSON, EventEmitter)
+Object.keys(EventEmitter.prototype).forEach(function (k) {
+    ReloadJSON.prototype[k] = deprecate.function(ReloadJSON.prototype[k])
+})
 
 // Start reading a json file
 ReloadJSON.prototype.read = function (path) {
@@ -55,7 +62,7 @@ ReloadJSON.prototype.read = function (path) {
         if (err) {
             // If an error occurs the loader needs to be invalidated.
             files[path] = null;
-            return self.emit('error', err);
+            return
         }
 
         // Once loaded store data in cache and configure a watch on the
@@ -63,7 +70,7 @@ ReloadJSON.prototype.read = function (path) {
         data = args[0];
         files[path] = data
         self.configureWatch(path);
-        self.emit('load', path, data);
+        EventEmitter.prototype.emit.call(self, 'load', path, data)
     });
 
     return file;
@@ -88,7 +95,7 @@ ReloadJSON.prototype.configureWatch = function (path) {
     // Make sure old data is not used again
     watch.on('change', function (event, filename) {
         self.files[path] = null;
-        self.emit('change', event, filename);
+        EventEmitter.prototype.emit.call(self, 'change', event, filename)
     });
 
     // Trigger a new read of the file after a debounce timeout, it's
@@ -100,9 +107,7 @@ ReloadJSON.prototype.configureWatch = function (path) {
         }
     }, delay));
 
-    watch.on('error', function (err) {
-        self.emit('error', err);
-    });
+    watch.on('error', function () {})
 }
 
 // Load json from the specified path. The result is cached and multiple request

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "debounce": "^1.0.0",
+    "depd": "^1.0.1",
     "ee-first": "^1.0.5"
   },
   "devDependencies": {

--- a/test/component/reload.coffee
+++ b/test/component/reload.coffee
@@ -22,7 +22,6 @@ describe "reload-json", ->
     errorcb = sinon.stub()
     reload = new Reload
       delay: 50
-    reload.on 'error', errorcb
     fs.writeFile filepath, JSON.stringify(file: 'test.json'), (err) ->
       done()
 


### PR DESCRIPTION
It does not add much as reacting to changes is orthogonal to the
intended use case of the module. In addition the error event was a pain
as it forced you to set up a listener so that is already disabled.
`change` and `load` is still emitted but any use of `on` results in a
deprecation warning.

Fixes #6
